### PR TITLE
Make dde client handle cancellation token

### DIFF
--- a/Source/NDde/Client/DdeClient.cs
+++ b/Source/NDde/Client/DdeClient.cs
@@ -420,20 +420,12 @@ namespace NDde.Client
             }
         }
 
-        /// <summary>
-        ///     This establishes a conversation with a server that supports the specified service name and topic name pair.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        ///     This is thrown when the client is already connected.
-        /// </exception>
-        /// <exception cref="DdeException">
-        ///     This is thrown when the client could not connect to the server.
-        /// </exception>
-        public virtual Task ConnectAsync()
+        ///<inheritdoc cref="IDdeClient"/>
+        public virtual Task ConnectAsync(CancellationToken cancellationToken = default)
         {
             try
             {
-                return Task.Factory.StartNew(Connect);
+                return Task.Factory.StartNew(Connect, cancellationToken);
             }
             catch (DdemlException e)
             {
@@ -512,21 +504,12 @@ namespace NDde.Client
             }
         }
 
-        /// <summary>
-        ///     This terminates the current conversation.
-        /// </summary>
-        /// <event cref="Disconnected" />
-        /// <exception cref="InvalidOperationException">
-        ///     This is thrown when the client was not previously connected.
-        /// </exception>
-        /// <exception cref="DdeException">
-        ///     This is thown when the client could not disconnect from the server.
-        /// </exception>
-        public virtual Task DisconnectAsync()
+        ///<inheritdoc cref="IDdeClient"/>
+        public virtual Task DisconnectAsync(CancellationToken cancellationToken = default)
         {
             try
             {
-                return Task.Factory.StartNew(Disconnect);
+                return Task.Factory.StartNew(Disconnect, cancellationToken);
             }
             catch (DdemlException e)
             {
@@ -573,25 +556,12 @@ namespace NDde.Client
             }
         }
 
-        /// <summary>
-        ///     This pauses the current conversation.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        ///     This is thrown when the conversation is already paused.
-        /// </exception>
-        /// <exception cref="DdeException">
-        ///     This is thrown when the conversation could not be paused or when the client is not connected.
-        /// </exception>
-        /// <remarks>
-        ///     Synchronous operations will timeout if the conversation is paused.  Asynchronous operations can begin, but will not
-        ///     complete until the
-        ///     conversation has resumed.
-        /// </remarks>
-        public virtual Task PauseAsync()
+        ///<inheritdoc cref="IDdeClient"/>
+        public virtual Task PauseAsync(CancellationToken cancellationToken = default)
         {
             try
             {
-                return Task.Factory.StartNew(Pause);
+                return Task.Factory.StartNew(Pause, cancellationToken);
             }
             catch (DdemlException e)
             {
@@ -633,20 +603,12 @@ namespace NDde.Client
             }
         }
 
-        /// <summary>
-        ///     This resumes the current conversation.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        ///     This is thrown when the conversation was not previously paused or when the client is not connected.
-        /// </exception>
-        /// <exception cref="DdeException">
-        ///     This is thrown when the conversation could not be resumed.
-        /// </exception>
-        public virtual Task ResumeAsync()
+        ///<inheritdoc cref="IDdeClient"/>
+        public virtual Task ResumeAsync(CancellationToken cancellationToken = default)
         {
             try
             {
-                return Task.Factory.StartNew(Resume);
+                return Task.Factory.StartNew(Resume, cancellationToken);
             }
             catch (DdemlException e)
             {
@@ -787,32 +749,12 @@ namespace NDde.Client
             }
         }
 
-        /// <summary>
-        ///     This begins an asynchronous operation to send a command to the server application.
-        /// </summary>
-        /// <param name="command">
-        ///     The command to be sent to the server application.
-        /// </param>
-        /// <returns>
-        ///     An <c>Task</c> object for this operation.
-        /// </returns>
-        /// <exception cref="ArgumentException">
-        ///     This is thown when command exceeds 255 characters.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
-        ///     This is thrown when command is a null reference.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">
-        ///     This is thrown when the client is not connected.
-        /// </exception>
-        /// <exception cref="DdeException">
-        ///     This is thrown when the asynchronous operation could not begin.
-        /// </exception>
-        public virtual Task ExecuteAsync(string command)
+        ///<inheritdoc cref="IDdeClient"/>
+        public virtual Task ExecuteAsync(string command, CancellationToken cancellationToken = default)
         {
             try
             {
-                return Task.Factory.FromAsync(BeginExecute(command, null, null), EndExecute);
+                return Task.Factory.FromAsync(BeginExecute(command, null, null), EndExecute).HandleCancellation(cancellationToken);
             }
             catch (DdemlException e)
             {
@@ -1047,35 +989,12 @@ namespace NDde.Client
             }
         }
 
-        /// <summary>
-        ///     This begins an asynchronous operation to send data to the server application.
-        /// </summary>
-        /// <param name="item">
-        ///     An item name supported by the current conversation.
-        /// </param>
-        /// <param name="data">
-        ///     The data to send.
-        /// </param>
-        /// <returns>
-        ///     An <c>Task</c> object for this operation.
-        /// </returns>
-        /// <exception cref="ArgumentException">
-        ///     This is thown when item exceeds 255 characters.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
-        ///     This is thrown when item or data is a null reference.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">
-        ///     This is thrown when the client is not connected.
-        /// </exception>
-        /// <exception cref="DdeException">
-        ///     This is thrown when the asynchronous operation could not begin.
-        /// </exception>
-        public virtual Task PokeAsync(string item, string data)
+        ///<inheritdoc cref="IDdeClient"/>
+        public virtual Task PokeAsync(string item, string data, CancellationToken cancellationToken = default)
         {
             try
             {
-                return PokeAsync(item, Context.Encoding.GetBytes(data + "\0"), 1);
+                return PokeAsync(item, Context.Encoding.GetBytes(data + "\0"), 1, cancellationToken);
             }
             catch (DdemlException e)
             {
@@ -1087,38 +1006,12 @@ namespace NDde.Client
             }
         }
 
-        /// <summary>
-        ///     This begins an asynchronous operation to send data to the server application.
-        /// </summary>
-        /// <param name="item">
-        ///     An item name supported by the current conversation.
-        /// </param>
-        /// <param name="data">
-        ///     The data to send.
-        /// </param>
-        /// <param name="format">
-        ///     The format of the data.
-        /// </param>
-        /// <returns>
-        ///     An <c>IAsyncResult</c> object for this operation.
-        /// </returns>
-        /// <exception cref="ArgumentException">
-        ///     This is thown when item exceeds 255 characters.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
-        ///     This is thrown when item or data is a null reference.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">
-        ///     This is thrown when the client is not connected.
-        /// </exception>
-        /// <exception cref="DdeException">
-        ///     This is thrown when the asynchronous operation could not begin.
-        /// </exception>
-        public virtual Task PokeAsync(string item, byte[] data, int format)
+        ///<inheritdoc cref="IDdeClient"/>
+        public virtual Task PokeAsync(string item, byte[] data, int format, CancellationToken cancellationToken = default)
         {
             try
             {
-                return Task.Factory.FromAsync(BeginPoke(item, data, format, null, null), EndPoke);
+                return Task.Factory.FromAsync(BeginPoke(item, data, format, null, null), EndPoke).HandleCancellation(cancellationToken);
             }
             catch (DdemlException e)
             {
@@ -1365,61 +1258,18 @@ namespace NDde.Client
             }
         }
 
-        /// <summary>
-        ///     This begins an asynchronous operation to request data using the specified item name.
-        /// </summary>
-        /// <param name="item">
-        ///     An item name supported by the current conversation.
-        /// </param>
-        /// <returns>
-        ///     An <c>Task</c> object for this operation.
-        /// </returns>
-        /// <exception cref="ArgumentException">
-        ///     This is thown when item exceeds 255 characters.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
-        ///     This is thrown when item is a null reference.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">
-        ///     This is thrown when the client is not connected.
-        /// </exception>
-        /// <exception cref="DdeException">
-        ///     This is thrown when the asynchronous operation could not begin.
-        /// </exception>
-        public virtual async Task<string> RequestAsync(string item)
+        ///<inheritdoc cref="IDdeClient"/>
+        public virtual async Task<string> RequestAsync(string item, CancellationToken cancellationToken = default)
         {
-            return Context.Encoding.GetString(await RequestAsync(item, 1));
+            return Context.Encoding.GetString(await RequestAsync(item, 1, cancellationToken));
         }
 
-        /// <summary>
-        ///     This begins an asynchronous operation to request data using the specified item name.
-        /// </summary>
-        /// <param name="item">
-        ///     An item name supported by the current conversation.
-        /// </param>
-        /// <param name="format">
-        ///     The format of the data to return.
-        /// </param>
-        /// <returns>
-        ///     An <c>IAsyncResult</c> object for this operation.
-        /// </returns>
-        /// <exception cref="ArgumentException">
-        ///     This is thown when item exceeds 255 characters.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
-        ///     This is thrown when item is a null reference.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">
-        ///     This is thrown when the client is not connected.
-        /// </exception>
-        /// <exception cref="DdeException">
-        ///     This is thrown when the asynchronous operation could not begin.
-        /// </exception>
-        public virtual Task<byte[]> RequestAsync(string item, int format)
+        ///<inheritdoc cref="IDdeClient"/>
+        public virtual Task<byte[]> RequestAsync(string item, int format, CancellationToken cancellationToken = default)
         {
             try
             {
-                return Task.Factory.FromAsync(BeginRequest(item, format, null, null), EndRequest);
+                return Task.Factory.FromAsync(BeginRequest(item, format, null, null), EndRequest).HandleCancellation(cancellationToken);
             }
             catch (DdemlException e)
             {
@@ -1630,39 +1480,12 @@ namespace NDde.Client
             }
         }
 
-        /// <summary>
-        ///     This begins an asynchronous operation to initiate an advise loop on the specified item name.
-        /// </summary>
-        /// <param name="item">
-        ///     An item name supported by the current conversation.
-        /// </param>
-        /// <param name="format">
-        ///     The format of the data to be returned.
-        /// </param>
-        /// <param name="hot">
-        ///     A bool indicating whether data should be included with the notification.
-        /// </param>
-        /// <returns>
-        ///     An <c>Task</c> object for this operation.
-        /// </returns>
-        /// <event cref="Advise" />
-        /// <exception cref="ArgumentException">
-        ///     This is thown when item exceeds 255 characters.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
-        ///     This is thrown when item is a null reference.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">
-        ///     This is thrown when the item is already being advised or when the client is not connected.
-        /// </exception>
-        /// <exception cref="DdeException">
-        ///     This is thrown when the asynchronous operation could not begin.
-        /// </exception>
-        public virtual Task StartAdviseAsync(string item, int format, bool hot)
+        ///<inheritdoc cref="IDdeClient"/>
+        public virtual Task StartAdviseAsync(string item, int format, bool hot, CancellationToken cancellationToken = default)
         {
             try
             {
-                return StartAdviseAsync(item, format, hot, true, null);
+                return StartAdviseAsync(item, format, hot, true, null, cancellationToken);
             }
             catch (DdemlException e)
             {
@@ -1674,45 +1497,12 @@ namespace NDde.Client
             }
         }
 
-        /// <summary>
-        ///     This begins an asynchronous operation to initiate an advise loop on the specified item name.
-        /// </summary>
-        /// <param name="item">
-        ///     An item name supported by the current conversation.
-        /// </param>
-        /// <param name="format">
-        ///     The format of the data to be returned.
-        /// </param>
-        /// <param name="hot">
-        ///     A bool indicating whether data should be included with the notification.
-        /// </param>
-        /// <param name="acknowledge">
-        ///     A bool indicating whether the client should acknowledge each advisory before the server will send send another.
-        /// </param>
-        /// <param name="adviseState">
-        ///     An application defined data object to associate with this advise loop.
-        /// </param>
-        /// <returns>
-        ///     An <c>Task</c> object for this operation.
-        /// </returns>
-        /// <event cref="Advise" />
-        /// <exception cref="ArgumentException">
-        ///     This is thown when item exceeds 255 characters.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
-        ///     This is thrown when item is a null reference.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">
-        ///     This is thrown when the item is already being advised or when the client is not connected.
-        /// </exception>
-        /// <exception cref="DdeException">
-        ///     This is thrown when the asynchronous operation could not begin.
-        /// </exception>
-        public virtual Task StartAdviseAsync(string item, int format, bool hot, bool acknowledge, object adviseState)
+        ///<inheritdoc cref="IDdeClient"/>
+        public virtual Task StartAdviseAsync(string item, int format, bool hot, bool acknowledge, object adviseState, CancellationToken cancellationToken = default)
         {
             try
             {
-                return Task.Factory.FromAsync(BeginStartAdvise(item, format, hot, acknowledge, null, null, adviseState), EndStartAdvise);
+                return Task.Factory.FromAsync(BeginStartAdvise(item, format, hot, acknowledge, null, null, adviseState), EndStartAdvise).HandleCancellation(cancellationToken);
             }
             catch (DdemlException e)
             {
@@ -1914,32 +1704,12 @@ namespace NDde.Client
             }
         }
 
-        /// <summary>
-        ///     This begins an asynchronous operation to terminate the advise loop for the specified item name.
-        /// </summary>
-        /// <param name="item">
-        ///     An item name that has an active advise loop.
-        /// </param>
-        /// <returns>
-        ///     An <c>Task</c> object for this operation.
-        /// </returns>
-        /// <exception cref="ArgumentException">
-        ///     This is thown when item exceeds 255 characters.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
-        ///     This is thrown when item is a null reference.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">
-        ///     This is thrown when the item is not being advised or when the client is not connected.
-        /// </exception>
-        /// <exception cref="DdeException">
-        ///     This is thrown when the asynchronous operation could not begin.
-        /// </exception>
-        public virtual Task StopAdviseAsync(string item)
+        ///<inheritdoc cref="IDdeClient"/>
+        public virtual Task StopAdviseAsync(string item, CancellationToken cancellationToken = default)
         {
             try
             {
-                return Task.Factory.FromAsync(BeginStopAdvise(item, null, null), EndStopAdvise);
+                return Task.Factory.FromAsync(BeginStopAdvise(item, null, null), EndStopAdvise).HandleCancellation(cancellationToken);
             }
             catch (DdemlException e)
             {

--- a/Source/NDde/Client/IDdeClient.cs
+++ b/Source/NDde/Client/IDdeClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using NDde.Advanced;
 
@@ -81,13 +82,14 @@ namespace NDde.Client
         /// <summary>
         ///     This establishes a conversation with a server that supports the specified service name and topic name pair.
         /// </summary>
+        /// <param name="cancellationToken">For cancellening the operation</param>
         /// <exception cref="InvalidOperationException">
         ///     This is thrown when the client is already connected.
         /// </exception>
         /// <exception cref="DdeException">
         ///     This is thrown when the client could not connect to the server.
         /// </exception>
-        Task ConnectAsync();
+        Task ConnectAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This establishes a conversation with a server that supports the specified service name and topic name pair.
@@ -112,6 +114,7 @@ namespace NDde.Client
         /// <summary>
         ///     This terminates the current conversation.
         /// </summary>
+        /// <param name="cancellationToken">For cancellening the operation</param>
         /// <event cref="DdeClient.Disconnected" />
         /// <exception cref="InvalidOperationException">
         ///     This is thrown when the client was not previously connected.
@@ -119,7 +122,7 @@ namespace NDde.Client
         /// <exception cref="DdeException">
         ///     This is thown when the client could not disconnect from the server.
         /// </exception>
-        Task DisconnectAsync();
+        Task DisconnectAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This pauses the current conversation.
@@ -140,6 +143,7 @@ namespace NDde.Client
         /// <summary>
         ///     This pauses the current conversation.
         /// </summary>
+        /// <param name="cancellationToken">For cancellening the operation</param>
         /// <exception cref="InvalidOperationException">
         ///     This is thrown when the conversation is already paused.
         /// </exception>
@@ -151,7 +155,7 @@ namespace NDde.Client
         ///     complete until the
         ///     conversation has resumed.
         /// </remarks>
-        Task PauseAsync();
+        Task PauseAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This resumes the current conversation.
@@ -167,13 +171,14 @@ namespace NDde.Client
         /// <summary>
         ///     This resumes the current conversation.
         /// </summary>
+        /// <param name="cancellationToken">For cancellening the operation</param>
         /// <exception cref="InvalidOperationException">
         ///     This is thrown when the conversation was not previously paused or when the client is not connected.
         /// </exception>
         /// <exception cref="DdeException">
         ///     This is thrown when the conversation could not be resumed.
         /// </exception>
-        Task ResumeAsync();
+        Task ResumeAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This terminates an asychronous operation.
@@ -247,6 +252,7 @@ namespace NDde.Client
         /// <param name="command">
         ///     The command to be sent to the server application.
         /// </param>
+        /// <param name="cancellationToken">For cancellening the operation</param>
         /// <returns>
         ///     An <c>Task</c> object for this operation.
         /// </returns>
@@ -262,7 +268,7 @@ namespace NDde.Client
         /// <exception cref="DdeException">
         ///     This is thrown when the asynchronous operation could not begin.
         /// </exception>
-        Task ExecuteAsync(string command);
+        Task ExecuteAsync(string command, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This begins an asynchronous operation to send a command to the server application.
@@ -407,6 +413,7 @@ namespace NDde.Client
         /// <param name="data">
         ///     The data to send.
         /// </param>
+        /// <param name="cancellationToken">For cancellening the operation</param>
         /// <returns>
         ///     An <c>Task</c> object for this operation.
         /// </returns>
@@ -422,7 +429,7 @@ namespace NDde.Client
         /// <exception cref="DdeException">
         ///     This is thrown when the asynchronous operation could not begin.
         /// </exception>
-        Task PokeAsync(string item, string data);
+        Task PokeAsync(string item, string data, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This begins an asynchronous operation to send data to the server application.
@@ -436,6 +443,7 @@ namespace NDde.Client
         /// <param name="format">
         ///     The format of the data.
         /// </param>
+        /// <param name="cancellationToken">For cancellening the operation</param>
         /// <returns>
         ///     An <c>IAsyncResult</c> object for this operation.
         /// </returns>
@@ -451,7 +459,7 @@ namespace NDde.Client
         /// <exception cref="DdeException">
         ///     This is thrown when the asynchronous operation could not begin.
         /// </exception>
-        Task PokeAsync(string item, byte[] data, int format);
+        Task PokeAsync(string item, byte[] data, int format, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This begins an asynchronous operation to send data to the server application.
@@ -600,6 +608,7 @@ namespace NDde.Client
         /// <param name="item">
         ///     An item name supported by the current conversation.
         /// </param>
+        /// <param name="cancellationToken">For cancellening the operation</param>
         /// <returns>
         ///     An <c>Task</c> object for this operation.
         /// </returns>
@@ -615,7 +624,7 @@ namespace NDde.Client
         /// <exception cref="DdeException">
         ///     This is thrown when the asynchronous operation could not begin.
         /// </exception>
-        Task<string> RequestAsync(string item);
+        Task<string> RequestAsync(string item, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This begins an asynchronous operation to request data using the specified item name.
@@ -626,6 +635,7 @@ namespace NDde.Client
         /// <param name="format">
         ///     The format of the data to return.
         /// </param>
+        /// <param name="cancellationToken">For cancellening the operation</param>
         /// <returns>
         ///     An <c>IAsyncResult</c> object for this operation.
         /// </returns>
@@ -641,7 +651,7 @@ namespace NDde.Client
         /// <exception cref="DdeException">
         ///     This is thrown when the asynchronous operation could not begin.
         /// </exception>
-        Task<byte[]> RequestAsync(string item, int format);
+        Task<byte[]> RequestAsync(string item, int format, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This begins an asynchronous operation to request data using the specified item name.
@@ -784,6 +794,7 @@ namespace NDde.Client
         /// <param name="hot">
         ///     A bool indicating whether data should be included with the notification.
         /// </param>
+        /// <param name="cancellationToken">For cancellening the operation</param>
         /// <returns>
         ///     An <c>Task</c> object for this operation.
         /// </returns>
@@ -800,7 +811,7 @@ namespace NDde.Client
         /// <exception cref="DdeException">
         ///     This is thrown when the asynchronous operation could not begin.
         /// </exception>
-        Task StartAdviseAsync(string item, int format, bool hot);
+        Task StartAdviseAsync(string item, int format, bool hot, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This begins an asynchronous operation to initiate an advise loop on the specified item name.
@@ -820,6 +831,7 @@ namespace NDde.Client
         /// <param name="adviseState">
         ///     An application defined data object to associate with this advise loop.
         /// </param>
+        /// <param name="cancellationToken">For cancellening the operation</param>
         /// <returns>
         ///     An <c>Task</c> object for this operation.
         /// </returns>
@@ -836,7 +848,7 @@ namespace NDde.Client
         /// <exception cref="DdeException">
         ///     This is thrown when the asynchronous operation could not begin.
         /// </exception>
-        Task StartAdviseAsync(string item, int format, bool hot, bool acknowledge, object adviseState);
+        Task StartAdviseAsync(string item, int format, bool hot, bool acknowledge, object adviseState, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This begins an asynchronous operation to initiate an advise loop on the specified item name.
@@ -967,6 +979,7 @@ namespace NDde.Client
         /// <param name="item">
         ///     An item name that has an active advise loop.
         /// </param>
+        /// <param name="cancellationToken">For cancellening the operation</param>
         /// <returns>
         ///     An <c>Task</c> object for this operation.
         /// </returns>
@@ -982,7 +995,7 @@ namespace NDde.Client
         /// <exception cref="DdeException">
         ///     This is thrown when the asynchronous operation could not begin.
         /// </exception>
-        Task StopAdviseAsync(string item);
+        Task StopAdviseAsync(string item, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This begins an asynchronous operation to terminate the advise loop for the specified item name.

--- a/Source/NDde/Client/TaskExtensions.cs
+++ b/Source/NDde/Client/TaskExtensions.cs
@@ -1,0 +1,65 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace NDde.Client
+{
+    // Kindly borrowed from https://stackoverflow.com/a/24981908
+    internal static class TaskExtensions
+    {
+        internal static async Task<TResult> HandleCancellation<TResult>(
+            this Task<TResult> asyncTask,
+            CancellationToken cancellationToken)
+        {
+            // Create another task that completes as soon as cancellation is requested.
+            // http://stackoverflow.com/a/18672893/1149773
+            var tcs = new TaskCompletionSource<TResult>();
+            cancellationToken.Register(() =>
+                tcs.TrySetCanceled(), useSynchronizationContext: false);
+            var cancellationTask = tcs.Task;
+
+            // Create a task that completes when either the async operation completes,
+            // or cancellation is requested.
+            var readyTask = await Task.WhenAny(asyncTask, cancellationTask);
+
+            // In case of cancellation, register a continuation to observe any unhandled
+            // exceptions from the asynchronous operation (once it completes).
+            // In .NET 4.0, unobserved task exceptions would terminate the process.
+            if (readyTask == cancellationTask)
+            {
+                var _ = asyncTask.ContinueWith(_ => asyncTask.Exception,
+                    TaskContinuationOptions.OnlyOnFaulted |
+                    TaskContinuationOptions.ExecuteSynchronously);
+            }
+
+            return await readyTask;
+        }
+
+        internal static async Task HandleCancellation(
+            this Task asyncTask,
+            CancellationToken cancellationToken)
+        {
+            // Create another task that completes as soon as cancellation is requested.
+            // http://stackoverflow.com/a/18672893/1149773
+            var tcs = new TaskCompletionSource();
+            cancellationToken.Register(() =>
+                tcs.TrySetCanceled(), false);
+            var cancellationTask = tcs.Task;
+
+            // Create a task that completes when either the async operation completes,
+            // or cancellation is requested.
+            var readyTask = await Task.WhenAny(asyncTask, cancellationTask);
+
+            // In case of cancellation, register a continuation to observe any unhandled
+            // exceptions from the asynchronous operation (once it completes).
+            // In .NET 4.0, unobserved task exceptions would terminate the process.
+            if (readyTask == cancellationTask)
+            {
+                var _ = asyncTask.ContinueWith(_ => asyncTask.Exception,
+                    TaskContinuationOptions.OnlyOnFaulted |
+                    TaskContinuationOptions.ExecuteSynchronously);
+            }
+
+            await readyTask;
+        }
+    }
+}


### PR DESCRIPTION
Usually the IO involved in DDE call is limited to a message pump.
Which should not affect us when a operation is cancelled.